### PR TITLE
Add quick way to load middleware to ajax validation

### DIFF
--- a/src/Utilities/AjaxValidation/AjaxValidationController.php
+++ b/src/Utilities/AjaxValidation/AjaxValidationController.php
@@ -11,6 +11,17 @@ use Validator;
 
 class AjaxValidationController extends Controller
 {
+    public function __construct()
+    {
+        //Load middleware normale is loaded by the action route
+        if(request()->has('_middleware')) {
+            if (!is_array($middleware = request()->get('_middleware'))) {
+                $middleware = [$middleware];
+            }
+
+            $this->middleware($middleware);
+        }
+    }
 
     /**
      * Controller-method for ajax-validation.


### PR DESCRIPTION
A quick fix, is not really sexy but works and as I see AjaxRequest is obsolete in v2.0 so may this is good enough.